### PR TITLE
conftest: edit allure folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ ENV DOCKERRUN=1
 
 # Set working directore for our project
 WORKDIR /app
-# Set volume for allure report files
-VOLUME /allure_result
 # Chrome browser and Allure dependency installation
 # default-jre, default-jdk - for Allure, curl for downloading, rest of all - for Chrome browser
 RUN apt-get update && apt-get install -y \
@@ -56,6 +54,8 @@ COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 # Copy all project files in docker image
 COPY . .
+# Set volume for allure report files
+# VOLUME /allure_result
 # Expose our port to the world
 EXPOSE 9999
 # Run tests and make Allure report

--- a/conftest.py
+++ b/conftest.py
@@ -47,8 +47,8 @@ def pytest_runtest_makereport(item, call):
             # logger.error(f'{status} - {test_name}. Reason: {str(call.excinfo)}')
             try:
                 driver = item.funcargs['driver']
-                driver.save_screenshot('allure-results/screenshot.png')
-                allure.attach.file('allure-results/screenshot.png', name='Screenshot',
+                driver.save_screenshot('allure_result/screenshot.png')
+                allure.attach.file('allure_result/screenshot.png', name='Screenshot',
                                    attachment_type=allure.attachment_type.PNG)
                 allure.attach(driver.page_source, name="HTML source", attachment_type=allure.attachment_type.HTML)
             except Exception as e:
@@ -57,7 +57,7 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.fixture(scope="session", autouse=True)
 def clear_allure_results_folder():
-    allure_report_dir = "allure-results"
+    allure_report_dir = "allure_result"
     if os.path.exists(allure_report_dir):
         for file_name in os.listdir(allure_report_dir):
             file_path = os.path.join(allure_report_dir, file_name)


### PR DESCRIPTION
conftest.py uses allure_result directory for allure reports, 
but Dockerfile specifies allure-results volume. 
this PR fixes the difference in confttest.py.